### PR TITLE
Fix server environment bug in data providers

### DIFF
--- a/packages/data/base/utils/index.ts
+++ b/packages/data/base/utils/index.ts
@@ -20,7 +20,8 @@ import type {
  * Helper function to build URL with pagination parameters
  */
 function buildUrlWithParams(apiUrl: string, resource: string, pagination?: { page: number; perPage: number }, sort?: { field: string; order: 'asc' | 'desc' }, filter?: Record<string, unknown>): URL {
-  const url = new URL(`${apiUrl}/${resource}`, window.location.origin);
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+  const url = new URL(`${apiUrl}/${resource}`, origin);
   
   // Add pagination params if provided
   if (pagination) {

--- a/packages/data/providers/rest/index.ts
+++ b/packages/data/providers/rest/index.ts
@@ -78,7 +78,8 @@ export function createRestProvider(options: RestProviderOptions | string = '' as
   return {
     async getList({ resource, pagination, sort, filter }: GetListParams): Promise<GetListResult> {
       // Build URL with query parameters
-      const url = new URL(`${apiUrl}/${resource}`, window.location.origin);
+      const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+      const url = new URL(`${apiUrl}/${resource}`, origin);
       
       // Add parameters
       addPaginationParams(url, pagination);

--- a/packages/data/providers/zopio/index.ts
+++ b/packages/data/providers/zopio/index.ts
@@ -60,7 +60,8 @@ export function createZopioProvider(config: ZopioClientConfig): CrudProvider {
   return {
     async getList({ resource, pagination, sort, filter }: GetListParams): Promise<GetListResult> {
       // Build URL with query parameters
-      const url = new URL(buildUrl(resource), window.location.origin);
+      const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+      const url = new URL(buildUrl(resource), origin);
       
       // Add parameters
       addPaginationParams(url, pagination);


### PR DESCRIPTION
## Summary
- protect against `window` being undefined in data provider utilities

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e23c43b0c8325bc9a551350f359a2