### PR TITLE
Update docs for bump-deps usage

### DIFF
--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -33,13 +33,13 @@ This will clone the latest version of zopio into a temporary directory, apply th
 
 ## Upgrading dependencies
 
-You can upgrade all the dependencies in all your `package.json` files and installs the new versions with the `bump-deps` command:
+You can update the dependency versions in all your `package.json` files with the `bump-deps` command:
 
 ```sh Terminal
 pnpm bump-deps
 ```
 
-This will update all the dependencies in your `package.json` files and install the new versions.
+This command only updates the `package.json` files. Run `pnpm install` (or `pnpm install -r`) afterward to actually install the upgraded versions.
 
 <Tip>You should run a `pnpm build` after running `bump-deps` to ensure the project builds correctly. You should also run `pnpm dev` and ensure the project runs correctly in runtime.</Tip>
 


### PR DESCRIPTION
## Summary
- clarify that `bump-deps` only updates `package.json`
- mention running `pnpm install` to install upgraded packages

## Testing
- `pnpm lint` *(fails: Request was cancelled due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_685e2c043ed88325a862f5cf69cc0e4a