### PR TITLE
fix(ci): handle fork PRs in workflow permissions

### DIFF
--- a/.github/workflows/pr-assignment.yml
+++ b/.github/workflows/pr-assignment.yml
@@ -66,6 +66,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
+            const isFork = pr.head.repo.full_name !== context.payload.repository.full_name;
+
+            // Skip assignment for fork PRs if they don't have write permissions
+            if (isFork) {
+              console.log(`PR #${pr.number} is from a fork. Assignment may fail due to permissions.`);
+            }
 
             // Only assign if no assignees exist to avoid overwriting manual assignments
             if (pr.assignees.length === 0) {
@@ -78,18 +84,26 @@ jobs:
                 });
                 console.log(`Assigned PR #${pr.number} to author: ${pr.user.login}`);
               } catch (error) {
-                console.error(`Error assigning PR to author: ${error.message}`);
-                // Try alternative method if the first one fails
-                try {
-                  await github.rest.pulls.update({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: pr.number,
-                    assignees: [pr.user.login]
-                  });
-                  console.log(`Assigned PR #${pr.number} to author using alternative method`);
-                } catch (altError) {
-                  console.error(`Alternative assignment method also failed: ${altError.message}`);
+                if (error.status === 403 && isFork) {
+                  console.log(`Cannot assign PR author for fork PR due to permissions. This is expected behavior.`);
+                } else {
+                  console.error(`Error assigning PR to author: ${error.message}`);
+                  // Try alternative method if the first one fails
+                  try {
+                    await github.rest.pulls.update({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: pr.number,
+                      assignees: [pr.user.login]
+                    });
+                    console.log(`Assigned PR #${pr.number} to author using alternative method`);
+                  } catch (altError) {
+                    if (altError.status === 403 && isFork) {
+                      console.log(`Cannot assign PR author for fork PR due to permissions. This is expected behavior.`);
+                    } else {
+                      console.error(`Alternative assignment method also failed: ${altError.message}`);
+                    }
+                  }
                 }
               }
             } else {
@@ -302,7 +316,10 @@ jobs:
       # Step 3: Add an informative comment to the PR about reviewer assignments
       # This provides transparency about the automated assignment process
       # and helps contributors understand who will be reviewing their code
+      # Note: This step is skipped for fork PRs due to permission limitations
       - name: Add reviewer assignment comment
+        # Skip comment for fork PRs as they don't have write permissions
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           # Authentication token to post comments on the PR

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -130,12 +130,19 @@ jobs:
               - \`wip/*\` - Work in progress`;
 
               if (context.payload.pull_request) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: message
-                });
+                // Check if this is a fork PR
+                const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
+                
+                if (!isFork) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body: message
+                  });
+                } else {
+                  console.log('Skipping comment for fork PR due to permission limitations');
+                }
 
                 try {
                   await github.rest.issues.addLabels({
@@ -243,28 +250,35 @@ jobs:
               const hasBreakingSection = body.toLowerCase().includes('breaking change');
 
               if (!hasBreakingSection) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: `⚠️ **Breaking Change Detected**
+                // Check if this is a fork PR
+                const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
+                
+                if (!isFork) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.payload.pull_request.number,
+                    body: `⚠️ **Breaking Change Detected**
 
-                  Your PR title indicates a breaking change (contains "!"), but the PR description doesn't include a "Breaking Changes" section.
+                    Your PR title indicates a breaking change (contains "!"), but the PR description doesn't include a "Breaking Changes" section.
 
-                  Please update your PR description to include:
-                  - A clear description of what is breaking
-                  - Migration instructions for users
-                  - Why this breaking change is necessary
+                    Please update your PR description to include:
+                    - A clear description of what is breaking
+                    - Migration instructions for users
+                    - Why this breaking change is necessary
 
-                  Example:
-                  \`\`\`
-                  ## Breaking Changes
+                    Example:
+                    \`\`\`
+                    ## Breaking Changes
 
-                  - Changed \`doSomething()\` API to require a config parameter
-                  - Migration: Update all calls from \`doSomething()\` to \`doSomething({ legacy: true })\`
-                  - This change allows for better extensibility and performance improvements
-                  \`\`\``
-                });
+                    - Changed \`doSomething()\` API to require a config parameter
+                    - Migration: Update all calls from \`doSomething()\` to \`doSomething({ legacy: true })\`
+                    - This change allows for better extensibility and performance improvements
+                    \`\`\``
+                  });
+                } else {
+                  console.log('Skipping breaking changes comment for fork PR due to permission limitations');
+                }
 
                 core.setFailed('PR contains breaking changes but lacks proper documentation');
               }
@@ -298,12 +312,20 @@ jobs:
             // Check file count limit
             if (changedFiles > 100) {
               core.setFailed(`❌ PR changes too many files (${changedFiles} files). Maximum allowed: 100 files.`);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: `### ❌ PR Size Check Failed\n\nThis PR changes ${changedFiles} files, exceeding the limit of 100 files.\n\nPlease split this PR into smaller, more focused changes.`
-              });
+              
+              // Check if this is a fork PR
+              const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
+              
+              if (!isFork) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: `### ❌ PR Size Check Failed\n\nThis PR changes ${changedFiles} files, exceeding the limit of 100 files.\n\nPlease split this PR into smaller, more focused changes.`
+                });
+              } else {
+                console.log('Skipping file count comment for fork PR due to permission limitations');
+              }
               return;
             }
 
@@ -343,12 +365,19 @@ jobs:
                 body: comment
               });
             } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: comment
-              });
+              // Check if this is a fork PR
+              const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
+              
+              if (!isFork) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: comment
+                });
+              } else {
+                console.log('Skipping PR size comment for fork PR due to permission limitations');
+              }
             }
 
             if (failed) {
@@ -367,18 +396,25 @@ jobs:
           script: |
             const validTypes = ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert', 'release'];
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: `## ❌ PR Validation Failed
+            // Check if this is a fork PR
+            const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
+            
+            if (!isFork) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `## ❌ PR Validation Failed
 
-              Please ensure your PR meets all requirements:
+                Please ensure your PR meets all requirements:
 
-              1. **Branch Naming**: Follow conventions like \`feat/description\`, \`fix/issue-123\`
-              2. **PR Title**: Use format \`<type>(<scope>): <subject>\` (e.g., \`feat(auth): add OAuth support\`)
-              3. **PR Size**: Keep changes under 5000 lines and 100 files
-              4. **Breaking Changes**: Document with "!" in title and description
+                1. **Branch Naming**: Follow conventions like \`feat/description\`, \`fix/issue-123\`
+                2. **PR Title**: Use format \`<type>(<scope>): <subject>\` (e.g., \`feat(auth): add OAuth support\`)
+                3. **PR Size**: Keep changes under 5000 lines and 100 files
+                4. **Breaking Changes**: Document with "!" in title and description
 
-              See our [Contributing Guide](https://github.com/zopiolabs/zopio/blob/main/.github/CONTRIBUTING.md) for details.`
-            });
+                See our [Contributing Guide](https://github.com/zopiolabs/zopio/blob/main/.github/CONTRIBUTING.md) for details.`
+              });
+            } else {
+              console.log('Skipping validation summary comment for fork PR due to permission limitations');
+            }


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow failures for PRs from forks
- Add conditional checks to skip comment creation when insufficient permissions
- Maintain existing functionality for non-fork PRs

## Related Issues
Fixes workflow failures seen in #14

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Details
The PR auto-assignment and validation workflows were failing when triggered by PRs from forks due to permission restrictions. Fork PRs run with read-only permissions and cannot create comments or labels on the PR.

### Changes Made:
1. **pr-assignment.yml**:
   - Added fork detection in the assign-author job
   - Made the reviewer comment step conditional (only runs for non-fork PRs)
   - Added graceful error handling for 403 permission errors

2. **pr-validation.yml**:
   - Added fork checks before all comment creation attempts
   - Maintained validation logic while skipping only the comment posting
   - Ensured the workflow still fails appropriately for validation errors

### How it Works:
- Detects if a PR is from a fork by comparing `head.repo.full_name` with `repository.full_name`
- Skips comment creation steps for fork PRs while still performing all validations
- Logs informative messages about skipped steps for debugging

## Test Plan
- [x] Tested workflow changes locally
- [ ] Verify workflows pass for fork PRs after merge
- [ ] Confirm non-fork PRs still receive comments as expected
- [ ] Check that validation failures still block PR merging

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] My commit messages follow the conventional commit format